### PR TITLE
build: add URL metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ VERSION = get_version("edx_user_state_client", "__init__.py")
 setup(
     name="edx_user_state_client",
     version=VERSION,
+    url="https://github.com/openedx/edx-user-state-client",
     packages=[
         "edx_user_state_client",
     ],


### PR DESCRIPTION
We rely on URL metadata to find GitHub repos from PyPI packages.